### PR TITLE
allow generated files to be saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Configure your `wkhtmltopdf` executable path under `app/config/packages/cangelis
         return PDF::loadHTML('<strong>Hello World</strong>')->lowquality()->pageSize('A2')->download();
     });
 
+    try {
+        PDF::loadView('pdf.letter')->save(public_path().'/letters/letter.pdf');
+    }
+    catch (Exception $e) {
+        echo "problem saving letter\n";
+    }
+
 ## Documentation
 
 You can see all the available methods in the full [documentation](https://github.com/cangelis/l4pdf/blob/master/DOCUMENTATION.md) file

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": ">=5.3.0",
         "cangelis/pdf": "1.1.*",
         "illuminate/http": "4.x",
-        "illuminate/view": "4.x"
+        "illuminate/view": "4.x",
+        "illuminate/filesystem": "4.x"
     },
     "autoload": {
         "psr-0": {

--- a/src/CanGelis/L4pdf/PDF.php
+++ b/src/CanGelis/L4pdf/PDF.php
@@ -46,6 +46,18 @@ class PDF extends \CanGelis\PDF\PDF {
 	}
 
 	/**
+	 * Save the PDF Document to a specified location
+	 *
+	 * @param string $path
+	 *
+	 * @return boolean
+	 */
+	public function save($path)
+	{
+		return File::put($path, $this->generatePDF());
+	}
+
+	/**
 	 * Creates a response object with proper Content-type for PDF Doc.
 	 *
 	 * @return \Illuminate\Http\Response

--- a/src/CanGelis/L4pdf/PDF.php
+++ b/src/CanGelis/L4pdf/PDF.php
@@ -2,6 +2,7 @@
 
 use Response;
 use View;
+use File;
 
 class PDF extends \CanGelis\PDF\PDF {
 


### PR DESCRIPTION
Love the initial cut of this this package. wkhtmltopdf is blazingly fast compared to the PHP libraries.

However, currently the package's two triggers, download() and stream() require a browser to be present to receive the result. So we can't queue the generation, or save the results to email to the visitor, or work with the package in Artisan commands.

This PR adds a save() trigger to store the generated output at a specified location and uses the Illuminate File class so that any file-related exceptions are generated for us, making possible all the use cases in the paragraph above.
