### PR TITLE
enable multiple views to be appended to the input

### DIFF
--- a/src/CanGelis/L4pdf/PDF.php
+++ b/src/CanGelis/L4pdf/PDF.php
@@ -17,7 +17,7 @@ class PDF extends \CanGelis\PDF\PDF {
 	 */
 	public function loadView($viewName, $data = array(), $mergeData = array())
 	{
-		$this->htmlContent = View::make($viewName, $data, $mergeData);
+		$this->htmlContent .= View::make($viewName, $data, $mergeData);
 
 		return $this;
 	}


### PR DESCRIPTION
A small but powerful suggestion ...

By concatenating the loaded view rather than assigning it, the loadView method can be called multiple times with each view's contents added to the input in the order in which they were loaded, allowing for smaller more targeted views and making it easier to re-use views already used elsewhere in the application.

This is consistent with wkhtmltopdf's willingness to allow multiple input files, though the end result is achieved differently.
